### PR TITLE
script to automate updating package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ And you're done!
 
 ## BeyondCompare has been updated! Help!
 
-When a new release of BeyondCompare is out in the wild, there's two different ways you can help out:
+When a new release of BeyondCompare is out in the wild, updating this package is easy:
 
- 1. Raise an issue so I can track it in my GitHub notifications
- 2. Submit a pull request with the necessary changes
+ 1. Fork this repository to your local environment
+ 2. Run the `.\Update-Version.ps1` to update the package artifacts
+ 3. Commit the changes to a branch and push it to your fork
+ 3. Submit a pull request
 
-It's not a hard task to update, just repetitive. So if you want to see it happen quicker, you can get involved!
+After I merge the pull request, I'll publish a new release to Chocolatey so they can review it.

--- a/Update-Version.ps1
+++ b/Update-Version.ps1
@@ -1,0 +1,30 @@
+function Update-Version
+{
+   $response = Invoke-WebRequest -Uri "http://www.scootersoftware.com/download.php"
+   $content = $response.Content
+
+   # Current Version:&nbsp; 4.1.3, build 20814, released Dec. 17, 2015
+   $isMatch = $content -match "Current Version:&nbsp; (?<release>\d{1,}\.\d{1,}\.\d{1,}), build (?<build>\d{1,}), released (?<month>[A-Za-z]{3})\. (?<day>[0-9]{1,2})\, (?<year>[0-9]{4})"
+
+   if ($isMatch)
+   {
+       $release = $matches.release
+       $build = $matches.build
+
+       $day = $matches.day
+       $month = $matches.month
+       $year = $matches.year
+
+       Write-Host "Found version $release.$build"
+       Write-Host "Release date: $day/$month/$year"
+
+       # TODO: modify nuspec
+       # TODO: modify chocolatey script
+   }
+   else
+   {
+       Write-Host "Unable to find the release on the download page. Check the regex above"
+   }
+}
+
+Update-Version

--- a/Update-Version.ps1
+++ b/Update-Version.ps1
@@ -18,7 +18,11 @@ function Update-Version
        Write-Host "Found version $release.$build"
        Write-Host "Release date: $day/$month/$year"
 
-       # TODO: modify nuspec
+       $nuspec = Join-Path $PSScriptRoot "beyondcompare.nuspec"
+       $contents = Get-Content $nuspec -Encoding Utf8
+       $newContents = $contents -replace "<version>\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}</version>", "<version>$release.$build</version>"
+       $newContents | Out-File $nuspec -Encoding Utf8
+
        # TODO: modify chocolatey script
    }
    else

--- a/Update-Version.ps1
+++ b/Update-Version.ps1
@@ -23,7 +23,14 @@ function Update-Version
        $newContents = $contents -replace "<version>\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}</version>", "<version>$release.$build</version>"
        $newContents | Out-File $nuspec -Encoding Utf8
 
-       # TODO: modify chocolatey script
+       $installScript = Join-Path $PSScriptRoot "tools/chocolateyInstall.ps1"
+       $contents = Get-Content $installScript -Encoding Utf8
+       $newContents = $contents -replace "'\d{1,}\.\d{1,}\.\d{1,}\.\d{1,}'", "'$release.$build'"
+       $newContents | Out-File $installScript -Encoding Utf8
+
+       Write-Host
+       Write-Host "Updated nuspec and install script, commit this change and open a pull request to the upstream repository on GitHub!"
+
    }
    else
    {

--- a/beyondcompare.nuspec
+++ b/beyondcompare.nuspec
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>beyondcompare</id>
-    <version>4.1.1.20615</version>
+    <version>4.1.3.20814</version>
     <title>Beyond Compare</title>
     <authors>Scooter Software</authors>
     <owners>Miguel Madero, Brendan Forster</owners>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
-$LCID = (Get-Culture).LCID
+﻿$LCID = (Get-Culture).LCID
 $german = @(3079,1031,5127,4103,2055)
 $french = @(2060,11276,3084,9228,12300,1036,5132,13324,6156,14348,10252,4108,7180)
-$version = '4.1.2.20720'
+$version = '4.1.3.20814'
 if ($LCID -in $german)
 {
     $url = 'http://www.scootersoftware.com/BCompare-de-'+$version+'.exe'

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,16 +1,17 @@
 $LCID = (Get-Culture).LCID
 $german = @(3079,1031,5127,4103,2055)
 $french = @(2060,11276,3084,9228,12300,1036,5132,13324,6156,14348,10252,4108,7180)
+$version = '4.1.2.20720'
 if ($LCID -in $german)
 {
-    $url = 'http://www.scootersoftware.com/BCompare-de-4.1.1.20615.exe'
+    $url = 'http://www.scootersoftware.com/BCompare-de-'+$version+'.exe'
 }
 elseif ($LCID -in $french)
 {
-    $url = 'http://www.scootersoftware.com/BCompare-fr-4.1.1.20615.exe'
+    $url = 'http://www.scootersoftware.com/BCompare-fr-'+$version+'.exe'
 }
 else
 {
-    $url = 'http://www.scootersoftware.com/BCompare-4.1.1.20615.exe'
+    $url = 'http://www.scootersoftware.com/BCompare-'+$version+'.exe'
 }
 Install-ChocolateyPackage 'beyondcompare' 'exe' '/SP- /VERYSILENT /NORESTART' $url


### PR DESCRIPTION
Supersedes #23 
Supersedes #22 

This PR updates to the latest version of BeyondCompare, but also scripts out the process so that it can be done by anyone.

When you run the `Update-Version.ps1` it:

 - scrapes the download page to find the current release
 - updates the nuspec file to this current version
 - updates the `chocolateyInstall` script to download this version

- [x] update docs