### PR TITLE
Use -contains instead of -in for PSv2 compatibility

### DIFF
--- a/src/tools/chocolateyInstall.ps1
+++ b/src/tools/chocolateyInstall.ps1
@@ -2,11 +2,11 @@
 $german = @(3079,1031,5127,4103,2055)
 $french = @(2060,11276,3084,9228,12300,1036,5132,13324,6156,14348,10252,4108,7180)
 $version = '4.1.3.20814'
-if ($LCID -in $german)
+if ($german -contains $LCID)
 {
     $url = 'http://www.scootersoftware.com/BCompare-de-'+$version+'.exe'
 }
-elseif ($LCID -in $french)
+elseif ($french -contains $LCID)
 {
     $url = 'http://www.scootersoftware.com/BCompare-fr-'+$version+'.exe'
 }


### PR DESCRIPTION
Instead of using -in, use -contains and reverse the operands to avoid
getting an error when using PowerShell v2.  (The -in operator was added in
PowerShell v3.)